### PR TITLE
feat: #3 Task 생성·목록·삭제 (TDD)

### DIFF
--- a/__tests__/utils/tree.test.ts
+++ b/__tests__/utils/tree.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { buildTree, flattenTree } from '@/lib/utils/tree';
+import type { Task, TaskNode } from '@/types/task';
+
+const makeTask = (id: string, parentId: string | null): Task => ({
+  id,
+  parentId,
+  title: `Task ${id}`,
+  description: null,
+  assignee: null,
+  status: 'todo',
+  progress: 0,
+  startDate: null,
+  dueDate: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+});
+
+describe('buildTree', () => {
+  it('빈 배열이면 빈 배열을 반환한다', () => {
+    expect(buildTree([])).toEqual([]);
+  });
+
+  it('단일 루트 노드는 children이 빈 배열인 TaskNode로 반환된다', () => {
+    const result = buildTree([makeTask('a', null)]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+    expect(result[0].children).toEqual([]);
+  });
+
+  it('3단계 계층을 올바른 트리로 변환한다', () => {
+    const tasks = [
+      makeTask('root', null),
+      makeTask('child', 'root'),
+      makeTask('grandchild', 'child'),
+    ];
+    const result = buildTree(tasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('root');
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children[0].id).toBe('child');
+    expect(result[0].children[0].children).toHaveLength(1);
+    expect(result[0].children[0].children[0].id).toBe('grandchild');
+  });
+
+  it('orphan 노드(parentId가 존재하지 않는 ID)는 루트 레벨로 처리한다', () => {
+    const tasks = [makeTask('orphan', 'nonexistent-id')];
+    const result = buildTree(tasks);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('orphan');
+    expect(result[0].children).toEqual([]);
+  });
+});
+
+describe('flattenTree', () => {
+  it('접힌 노드의 자손을 제외한 평면 배열을 반환한다', () => {
+    const grandchild: TaskNode = { ...makeTask('gc', 'child'), children: [] };
+    const child: TaskNode = { ...makeTask('child', 'root'), children: [grandchild] };
+    const root: TaskNode = { ...makeTask('root', null), children: [child] };
+
+    // root가 접힌 경우: root만 반환
+    const collapsed = flattenTree([root], new Set(['root']));
+    expect(collapsed.map((n) => n.id)).toEqual(['root']);
+  });
+
+  it('펼쳐진 트리는 모든 노드를 순서대로 반환한다', () => {
+    const grandchild: TaskNode = { ...makeTask('gc', 'child'), children: [] };
+    const child: TaskNode = { ...makeTask('child', 'root'), children: [grandchild] };
+    const root: TaskNode = { ...makeTask('root', null), children: [child] };
+
+    const all = flattenTree([root], new Set());
+    expect(all.map((n) => n.id)).toEqual(['root', 'child', 'gc']);
+  });
+});

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    await db.delete(tasks).where(eq(tasks.id, params.id));
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to delete task' }, { status: 500 });
+  }
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { asc } from 'drizzle-orm';
+
+export async function GET() {
+  try {
+    const rows = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
+    return NextResponse.json(rows);
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const [task] = await db
+      .insert(tasks)
+      .values({
+        title: body.title,
+        description: body.description ?? null,
+        assignee: body.assignee ?? null,
+        status: body.status ?? 'todo',
+        progress: body.progress ?? 0,
+        startDate: body.startDate ?? null,
+        dueDate: body.dueDate ?? null,
+        parentId: body.parentId ?? null,
+      })
+      .returning();
+    return NextResponse.json(task, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Failed to create task' }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,45 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { Box, Flex, Heading, Button } from '@chakra-ui/react'
+import type { Task } from '@/types/task'
+import { TaskList } from '@/components/task-list'
+import { TaskCreateModal } from '@/components/task-create-modal'
+
 export default function Home() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const fetchTasks = useCallback(async () => {
+    const res = await fetch('/api/tasks')
+    const data = await res.json()
+    setTasks(data)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { fetchTasks() }, [fetchTasks])
+
   return (
-    <main>
-      <h1>WBS</h1>
-    </main>
+    <Box p={6} maxW="1200px" mx="auto">
+      <Flex mb={4} align="center" justify="space-between">
+        <Heading size="lg">WBS</Heading>
+        <Flex gap={2}>
+          <Button onClick={() => setCreateOpen(true)}>+ 작업 추가</Button>
+          <Button variant="outline" disabled>CSV 내보내기</Button>
+          <Button variant="outline" disabled>CSV 불러오기</Button>
+        </Flex>
+      </Flex>
+
+      {!loading && (
+        <TaskList tasks={tasks} onTaskDeleted={fetchTasks} />
+      )}
+
+      <TaskCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => { setCreateOpen(false); fetchTasks() }}
+      />
+    </Box>
   )
 }

--- a/components/task-create-modal.tsx
+++ b/components/task-create-modal.tsx
@@ -1,56 +1,71 @@
 'use client'
 
 import { useState } from 'react'
-import {
-  Dialog,
-  Button,
-  Field,
-  Input,
-  Textarea,
-  NativeSelect,
-  CloseButton,
-  Portal,
-  VStack,
-} from '@chakra-ui/react'
+import { Box, Flex, Text, Portal } from '@chakra-ui/react'
+import type { Task } from '@/types/task'
+import type { DeliverableType } from '@/types/task'
+import { AddDeliverableForm, StagedDeliverableItem } from '@/components/deliverables-ui'
 
 interface Props {
   open: boolean
+  parentId?: string | null
+  allTasks: Task[]
   onClose: () => void
   onCreated: () => void
 }
 
-export function TaskCreateModal({ open, onClose, onCreated }: Props) {
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 12px', fontSize: '13px',
+  border: '1px solid #E2E8F0', borderRadius: '8px', background: 'white',
+  color: '#0F172A', outline: 'none', fontFamily: 'inherit', boxSizing: 'border-box',
+}
+
+const STATUSES = [
+  { value: 'todo', label: '할 일' },
+  { value: 'doing', label: '진행 중' },
+  { value: 'done', label: '완료' },
+] as const
+
+function FieldLabel({ label, en, required }: { label: string; en: string; required?: boolean }) {
+  return (
+    <label style={{ fontSize: '12px', fontWeight: 600, color: '#475569', marginBottom: '6px', display: 'block' }}>
+      {label}
+      {required && <span style={{ color: '#DC2626', marginLeft: '2px' }}>*</span>}
+      <span style={{ color: '#94A3B8', fontWeight: 400 }}> · {en}</span>
+    </label>
+  )
+}
+
+export function TaskCreateModal({ open, parentId, allTasks, onClose, onCreated }: Props) {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [assignee, setAssignee] = useState('')
-  const [status, setStatus] = useState('todo')
-  const [progress, setProgress] = useState('0')
+  const [status, setStatus] = useState<'todo' | 'doing' | 'done'>('todo')
   const [startDate, setStartDate] = useState('')
   const [dueDate, setDueDate] = useState('')
-  const [titleError, setTitleError] = useState('')
+  const [titleError, setTitleError] = useState(false)
   const [dateError, setDateError] = useState('')
+  const [delivs, setDelivs] = useState<{ name: string; type: DeliverableType }[]>([])
+
+  const parentTask = parentId ? allTasks.find(t => t.id === parentId) : null
 
   const reset = () => {
     setTitle(''); setDescription(''); setAssignee('')
-    setStatus('todo'); setProgress('0')
-    setStartDate(''); setDueDate('')
-    setTitleError(''); setDateError('')
+    setStatus('todo'); setStartDate(''); setDueDate('')
+    setTitleError(false); setDateError(''); setDelivs([])
   }
 
   const handleClose = () => { reset(); onClose() }
 
   const handleSave = async () => {
-    if (!title.trim()) {
-      setTitleError('제목을 입력해 주세요.')
-      return
-    }
+    if (!title.trim()) { setTitleError(true); return }
     if (startDate && dueDate && dueDate < startDate) {
       setDateError('목표 기한은 시작일 이후여야 합니다')
       return
     }
-    setTitleError(''); setDateError('')
+    setTitleError(false); setDateError('')
 
-    await fetch('/api/tasks', {
+    const res = await fetch('/api/tasks', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -58,112 +73,155 @@ export function TaskCreateModal({ open, onClose, onCreated }: Props) {
         description: description || null,
         assignee: assignee || null,
         status,
-        progress: Number(progress),
+        progress: 0,
         startDate: startDate || null,
         dueDate: dueDate || null,
+        parentId: parentId || null,
       }),
     })
+    if (res.ok && delivs.length > 0) {
+      const task = await res.json()
+      await Promise.all(delivs.map(d =>
+        fetch(`/api/tasks/${task.id}/deliverables`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: d.name, type: d.type }),
+        })
+      ))
+    }
     reset()
     onCreated()
   }
 
+  if (!open) return null
+
   return (
-    <Dialog.Root open={open} onOpenChange={(e) => !e.open && handleClose()}>
-      <Portal>
-        <Dialog.Backdrop />
-        <Dialog.Positioner>
-          <Dialog.Content maxW="480px">
-            <Dialog.Header>
-              <Dialog.Title>새 작업 추가</Dialog.Title>
-              <Dialog.CloseTrigger asChild>
-                <CloseButton />
-              </Dialog.CloseTrigger>
-            </Dialog.Header>
-            <Dialog.Body>
-              <VStack gap={3} align="stretch">
-                <Field.Root required invalid={!!titleError}>
-                  <Field.Label>제목</Field.Label>
-                  <Input
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    placeholder="작업 제목"
-                  />
-                  {titleError && <Field.ErrorText>{titleError}</Field.ErrorText>}
-                </Field.Root>
+    <Portal>
+      <Box
+        position="fixed" inset={0} zIndex={100}
+        style={{ background: 'rgba(15, 23, 42, 0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px' }}
+        onClick={handleClose}
+      >
+        <Box
+          style={{ width: '600px', maxHeight: '95vh', overflow: 'auto', background: 'white', borderRadius: '14px', boxShadow: '0 20px 50px rgba(15, 23, 42, 0.25)' }}
+          onClick={e => e.stopPropagation()}
+        >
+          {/* Header */}
+          <Flex px="24px" pt="20px" pb="16px" borderBottom="1px solid #EEF2F6" alignItems="flex-start" justifyContent="space-between">
+            <Box>
+              <Text style={{ fontSize: '11px', color: '#94A3B8', fontWeight: 700, letterSpacing: '0.6px', textTransform: 'uppercase' }}>
+                작업 추가 · New Task
+              </Text>
+              <Text style={{ fontSize: '17px', fontWeight: 700, color: '#0F172A', marginTop: '4px', letterSpacing: '-0.2px' }}>
+                새로운 작업을 만듭니다
+              </Text>
+              {parentTask && (
+                <Text style={{ fontSize: '12px', color: '#64748B', marginTop: '4px' }}>
+                  상위 작업: <b style={{ color: '#0F172A' }}>{parentTask.title}</b>
+                </Text>
+              )}
+            </Box>
+            <button onClick={handleClose} style={{ width: '30px', height: '30px', borderRadius: '8px', border: 'none', background: '#F1F5F9', color: '#64748B', cursor: 'pointer', fontSize: '16px' }}>✕</button>
+          </Flex>
 
-                <Field.Root>
-                  <Field.Label>설명</Field.Label>
-                  <Textarea
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="선택"
-                    rows={3}
-                  />
-                </Field.Root>
+          {/* Body */}
+          <Box px="24px" py="20px" display="flex" flexDirection="column" gap="16px">
+            {/* Title */}
+            <div>
+              <FieldLabel label="제목" en="Title" required />
+              <input
+                aria-label="제목"
+                style={{ ...inputStyle, borderColor: titleError ? '#DC2626' : '#E2E8F0' }}
+                placeholder="예: 사용자 인터뷰 진행"
+                value={title}
+                onChange={e => { setTitle(e.target.value); setTitleError(false) }}
+                autoFocus
+              />
+              {titleError && <div style={{ fontSize: '11px', color: '#DC2626', marginTop: '4px' }}>⚠ 제목은 필수 항목입니다</div>}
+            </div>
 
-                <Field.Root>
-                  <Field.Label>담당자</Field.Label>
-                  <Input
-                    value={assignee}
-                    onChange={(e) => setAssignee(e.target.value)}
-                    placeholder="선택"
-                  />
-                </Field.Root>
+            {/* Description */}
+            <div>
+              <FieldLabel label="설명" en="Description" />
+              <textarea
+                style={{ ...inputStyle, minHeight: '60px', resize: 'vertical' }}
+                placeholder="작업의 배경이나 완료 기준을 적어주세요"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+              />
+            </div>
 
-                <Field.Root>
-                  <Field.Label>상태</Field.Label>
-                  <NativeSelect.Root>
-                    <NativeSelect.Field
-                      value={status}
-                      onChange={(e) => setStatus(e.target.value)}
-                    >
-                      <option value="todo">할 일</option>
-                      <option value="doing">진행 중</option>
-                      <option value="done">완료</option>
-                    </NativeSelect.Field>
-                  </NativeSelect.Root>
-                </Field.Root>
+            {/* Assignee + Status */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+              <div>
+                <FieldLabel label="담당자" en="Assignee" />
+                <input aria-label="담당자" style={inputStyle} placeholder="이름 또는 핸들" value={assignee} onChange={e => setAssignee(e.target.value)} />
+              </div>
+              <div>
+                <FieldLabel label="상태" en="Status" />
+                <Flex gap={1}>
+                  {STATUSES.map(s => (
+                    <button key={s.value} onClick={() => setStatus(s.value)} style={{
+                      flex: 1, padding: '9px 6px', borderRadius: '8px', fontSize: '11px', fontWeight: 600, cursor: 'pointer',
+                      border: status === s.value ? '1.5px solid var(--c-accent)' : '1px solid #E2E8F0',
+                      background: status === s.value ? 'var(--c-accent-soft)' : 'white',
+                      color: status === s.value ? 'var(--c-accent)' : '#64748B',
+                    }}>
+                      {s.label}
+                    </button>
+                  ))}
+                </Flex>
+              </div>
+            </div>
 
-                <Field.Root>
-                  <Field.Label>진행률 (0~100)</Field.Label>
-                  <Input
-                    type="number"
-                    min={0}
-                    max={100}
-                    value={progress}
-                    onChange={(e) => setProgress(e.target.value)}
-                  />
-                </Field.Root>
+            {/* Dates */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+              <div>
+                <FieldLabel label="시작일" en="Start" />
+                <input aria-label="시작일" type="date" style={inputStyle} value={startDate} onChange={e => { setStartDate(e.target.value); setDateError('') }} />
+              </div>
+              <div>
+                <FieldLabel label="목표 기한" en="Due" />
+                <input
+                  aria-label="목표 기한"
+                  type="date"
+                  style={{ ...inputStyle, borderColor: dateError ? '#DC2626' : '#E2E8F0' }}
+                  value={dueDate}
+                  onChange={e => { setDueDate(e.target.value); setDateError('') }}
+                />
+                {dateError && <div style={{ fontSize: '11px', color: '#DC2626', marginTop: '4px' }}>⚠ {dateError}</div>}
+              </div>
+            </div>
 
-                <Field.Root>
-                  <Field.Label>시작일</Field.Label>
-                  <Input
-                    type="date"
-                    value={startDate}
-                    onChange={(e) => setStartDate(e.target.value)}
+            {/* Deliverables */}
+            <div>
+              <FieldLabel label="산출물" en="Deliverables" />
+              <Box display="flex" flexDirection="column" gap="6px">
+                <AddDeliverableForm onAdd={(name, type) => setDelivs(prev => [...prev, { name, type }])} />
+                {delivs.map((d, i) => (
+                  <StagedDeliverableItem
+                    key={i}
+                    name={d.name}
+                    type={d.type}
+                    onRemove={() => setDelivs(prev => prev.filter((_, j) => j !== i))}
                   />
-                </Field.Root>
+                ))}
+              </Box>
+            </div>
+          </Box>
 
-                <Field.Root invalid={!!dateError}>
-                  <Field.Label>목표 기한</Field.Label>
-                  <Input
-                    type="date"
-                    value={dueDate}
-                    onChange={(e) => setDueDate(e.target.value)}
-                  />
-                  {dateError && <Field.ErrorText>{dateError}</Field.ErrorText>}
-                </Field.Root>
-              </VStack>
-            </Dialog.Body>
-            <Dialog.Footer gap={2}>
-              <Dialog.ActionTrigger asChild>
-                <Button variant="outline" onClick={handleClose}>취소</Button>
-              </Dialog.ActionTrigger>
-              <Button onClick={handleSave}>저장</Button>
-            </Dialog.Footer>
-          </Dialog.Content>
-        </Dialog.Positioner>
-      </Portal>
-    </Dialog.Root>
+          {/* Footer */}
+          <Flex px="24px" py="14px" borderTop="1px solid #EEF2F6" justifyContent="space-between" alignItems="center" bg="#FAFBFC" style={{ borderRadius: '0 0 14px 14px' }}>
+            <Text style={{ fontSize: '11px', color: '#94A3B8' }}>
+              <kbd style={{ padding: '2px 6px', background: 'white', border: '1px solid #E2E8F0', borderRadius: '4px', fontSize: '10px' }}>Esc</kbd> 취소
+            </Text>
+            <Flex gap={2}>
+              <button onClick={handleClose} style={{ padding: '8px 14px', borderRadius: '8px', border: '1px solid #E2E8F0', background: 'white', color: '#334155', fontSize: '13px', fontWeight: 500, cursor: 'pointer' }}>취소</button>
+              <button onClick={handleSave} style={{ padding: '8px 14px', borderRadius: '8px', border: '1px solid var(--c-accent)', background: 'var(--c-accent)', color: 'white', fontSize: '13px', fontWeight: 500, cursor: 'pointer' }}>작업 만들기</button>
+            </Flex>
+          </Flex>
+        </Box>
+      </Box>
+    </Portal>
   )
 }

--- a/components/task-create-modal.tsx
+++ b/components/task-create-modal.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Dialog,
+  Button,
+  Field,
+  Input,
+  Textarea,
+  NativeSelect,
+  CloseButton,
+  Portal,
+  VStack,
+} from '@chakra-ui/react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onCreated: () => void
+}
+
+export function TaskCreateModal({ open, onClose, onCreated }: Props) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [assignee, setAssignee] = useState('')
+  const [status, setStatus] = useState('todo')
+  const [progress, setProgress] = useState('0')
+  const [startDate, setStartDate] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [titleError, setTitleError] = useState('')
+  const [dateError, setDateError] = useState('')
+
+  const reset = () => {
+    setTitle(''); setDescription(''); setAssignee('')
+    setStatus('todo'); setProgress('0')
+    setStartDate(''); setDueDate('')
+    setTitleError(''); setDateError('')
+  }
+
+  const handleClose = () => { reset(); onClose() }
+
+  const handleSave = async () => {
+    if (!title.trim()) {
+      setTitleError('제목을 입력해 주세요.')
+      return
+    }
+    if (startDate && dueDate && dueDate < startDate) {
+      setDateError('목표 기한은 시작일 이후여야 합니다')
+      return
+    }
+    setTitleError(''); setDateError('')
+
+    await fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: title.trim(),
+        description: description || null,
+        assignee: assignee || null,
+        status,
+        progress: Number(progress),
+        startDate: startDate || null,
+        dueDate: dueDate || null,
+      }),
+    })
+    reset()
+    onCreated()
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(e) => !e.open && handleClose()}>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content maxW="480px">
+            <Dialog.Header>
+              <Dialog.Title>새 작업 추가</Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+            <Dialog.Body>
+              <VStack gap={3} align="stretch">
+                <Field.Root required invalid={!!titleError}>
+                  <Field.Label>제목</Field.Label>
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="작업 제목"
+                  />
+                  {titleError && <Field.ErrorText>{titleError}</Field.ErrorText>}
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>설명</Field.Label>
+                  <Textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="선택"
+                    rows={3}
+                  />
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>담당자</Field.Label>
+                  <Input
+                    value={assignee}
+                    onChange={(e) => setAssignee(e.target.value)}
+                    placeholder="선택"
+                  />
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>상태</Field.Label>
+                  <NativeSelect.Root>
+                    <NativeSelect.Field
+                      value={status}
+                      onChange={(e) => setStatus(e.target.value)}
+                    >
+                      <option value="todo">할 일</option>
+                      <option value="doing">진행 중</option>
+                      <option value="done">완료</option>
+                    </NativeSelect.Field>
+                  </NativeSelect.Root>
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>진행률 (0~100)</Field.Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={progress}
+                    onChange={(e) => setProgress(e.target.value)}
+                  />
+                </Field.Root>
+
+                <Field.Root>
+                  <Field.Label>시작일</Field.Label>
+                  <Input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                  />
+                </Field.Root>
+
+                <Field.Root invalid={!!dateError}>
+                  <Field.Label>목표 기한</Field.Label>
+                  <Input
+                    type="date"
+                    value={dueDate}
+                    onChange={(e) => setDueDate(e.target.value)}
+                  />
+                  {dateError && <Field.ErrorText>{dateError}</Field.ErrorText>}
+                </Field.Root>
+              </VStack>
+            </Dialog.Body>
+            <Dialog.Footer gap={2}>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline" onClick={handleClose}>취소</Button>
+              </Dialog.ActionTrigger>
+              <Button onClick={handleSave}>저장</Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  )
+}

--- a/components/task-delete-dialog.tsx
+++ b/components/task-delete-dialog.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Dialog, Button, Text, Portal } from '@chakra-ui/react'
+import type { Task } from '@/types/task'
+
+interface Props {
+  task: Task
+  childCount: number
+  open: boolean
+  onClose: () => void
+  onDeleted: () => void
+}
+
+export function TaskDeleteDialog({ task, childCount, open, onClose, onDeleted }: Props) {
+  const handleConfirm = async () => {
+    await fetch(`/api/tasks/${task.id}`, { method: 'DELETE' })
+    onClose()
+    onDeleted()
+  }
+
+  const message =
+    childCount > 0
+      ? `이 작업과 하위 작업 ${childCount}개가 모두 삭제됩니다. 계속할까요?`
+      : '이 작업을 삭제합니다. 계속할까요?'
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(e) => !e.open && onClose()}
+      role="alertdialog"
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>작업 삭제</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Text>{message}</Text>
+            </Dialog.Body>
+            <Dialog.Footer gap={2}>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline" onClick={onClose}>취소</Button>
+              </Dialog.ActionTrigger>
+              <Button colorPalette="red" onClick={handleConfirm}>확인</Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  )
+}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { Table, Text, VStack } from '@chakra-ui/react'
+import type { Task } from '@/types/task'
+import { TaskRow } from '@/components/task-row'
+
+interface Props {
+  tasks: Task[]
+  onTaskDeleted: () => void
+}
+
+export function TaskList({ tasks, onTaskDeleted }: Props) {
+  if (tasks.length === 0) {
+    return (
+      <VStack py={16}>
+        <Text color="gray.500">
+          아직 작업이 없습니다. 첫 작업을 추가해 시작하세요.
+        </Text>
+      </VStack>
+    )
+  }
+
+  return (
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader>제목</Table.ColumnHeader>
+          <Table.ColumnHeader>담당자</Table.ColumnHeader>
+          <Table.ColumnHeader>상태</Table.ColumnHeader>
+          <Table.ColumnHeader>진행률</Table.ColumnHeader>
+          <Table.ColumnHeader>기간</Table.ColumnHeader>
+          <Table.ColumnHeader />
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {tasks.map((task) => (
+          <TaskRow
+            key={task.id}
+            task={task}
+            allTasks={tasks}
+            onDeleted={onTaskDeleted}
+          />
+        ))}
+      </Table.Body>
+    </Table.Root>
+  )
+}

--- a/components/task-row.tsx
+++ b/components/task-row.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+import { Table, Badge, Text, Progress, Menu, IconButton, HStack } from '@chakra-ui/react'
+import type { Task } from '@/types/task'
+import { TaskDeleteDialog } from '@/components/task-delete-dialog'
+
+const STATUS_MAP: Record<string, { label: string; colorPalette: string }> = {
+  todo:  { label: '할 일',  colorPalette: 'gray'   },
+  doing: { label: '진행 중', colorPalette: 'blue'  },
+  done:  { label: '완료',   colorPalette: 'green'  },
+}
+
+interface Props {
+  task: Task
+  allTasks: Task[]
+  onDeleted: () => void
+}
+
+export function TaskRow({ task, allTasks, onDeleted }: Props) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const childCount = allTasks.filter((t) => t.parentId === task.id).length
+  const status = STATUS_MAP[task.status] ?? STATUS_MAP.todo
+
+  const period =
+    task.startDate || task.dueDate
+      ? `${task.startDate ?? '?'} ~ ${task.dueDate ?? '?'}`
+      : null
+
+  return (
+    <>
+      <Table.Row>
+        <Table.Cell>{task.title}</Table.Cell>
+        <Table.Cell>{task.assignee ?? '—'}</Table.Cell>
+        <Table.Cell>
+          <Badge colorPalette={status.colorPalette}>{status.label}</Badge>
+        </Table.Cell>
+        <Table.Cell>
+          <HStack gap={2}>
+            <Text fontSize="sm" whiteSpace="nowrap">{task.progress}%</Text>
+            <Progress.Root value={task.progress} minW="60px" maxW="80px" size="xs">
+              <Progress.Track>
+                <Progress.Range />
+              </Progress.Track>
+            </Progress.Root>
+          </HStack>
+        </Table.Cell>
+        <Table.Cell whiteSpace="nowrap">{period ?? '—'}</Table.Cell>
+        <Table.Cell>
+          <Menu.Root>
+            <Menu.Trigger asChild>
+              <IconButton variant="ghost" size="xs" aria-label="메뉴">
+                ⋯
+              </IconButton>
+            </Menu.Trigger>
+            <Menu.Positioner>
+              <Menu.Content>
+                <Menu.Item
+                  value="delete"
+                  color="red.500"
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  삭제
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Positioner>
+          </Menu.Root>
+        </Table.Cell>
+      </Table.Row>
+
+      <TaskDeleteDialog
+        task={task}
+        childCount={childCount}
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onDeleted={onDeleted}
+      />
+    </>
+  )
+}

--- a/drizzle/0000_smiling_micromacro.sql
+++ b/drizzle/0000_smiling_micromacro.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"parent_id" uuid,
+	"title" text NOT NULL,
+	"description" text,
+	"assignee" text,
+	"status" text DEFAULT 'todo' NOT NULL,
+	"progress" integer DEFAULT 0 NOT NULL,
+	"start_date" date,
+	"due_date" date,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tasks_status_check" CHECK ("tasks"."status" in ('todo','doing','done')),
+	CONSTRAINT "tasks_progress_check" CHECK ("tasks"."progress" between 0 and 100)
+);
+--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_parent_id_tasks_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."tasks"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,126 @@
+{
+  "id": "5cddaa5b-6317-46c8-bb58-30d5470e8dc6",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee": {
+          "name": "assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_parent_id_tasks_id_fk": {
+          "name": "tasks_parent_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_status_check": {
+          "name": "tasks_status_check",
+          "value": "\"tasks\".\"status\" in ('todo','doing','done')"
+        },
+        "tasks_progress_check": {
+          "name": "tasks_progress_check",
+          "value": "\"tasks\".\"progress\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777118651813,
+      "tag": "0000_smiling_micromacro",
+      "breakpoints": true
+    }
+  ]
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,10 @@
+import type { APIRequestContext } from '@playwright/test';
+
+export async function cleanupTasks(request: APIRequestContext) {
+  const res = await request.get('/api/tasks');
+  const tasks: Array<{ id: string; parentId: string | null }> = await res.json();
+  // 루트 task만 삭제 — cascade FK가 하위 task를 자동 제거
+  for (const task of tasks.filter((t) => t.parentId === null)) {
+    await request.delete(`/api/tasks/${task.id}`);
+  }
+}

--- a/e2e/task-create.spec.ts
+++ b/e2e/task-create.spec.ts
@@ -7,20 +7,20 @@ test.beforeEach(async ({ request }) => {
 
 test('J2 — 최상위 작업 추가', async ({ page }) => {
   await page.goto('/');
-  await page.getByRole('button', { name: '+ 작업 추가' }).click();
+  await page.getByRole('button', { name: '작업 추가' }).click();
 
   await page.getByLabel('제목').fill('기획 회의');
   await page.getByLabel('담당자').fill('김PM');
   await page.getByLabel('시작일').fill('2026-05-01');
   await page.getByLabel('목표 기한').fill('2026-05-03');
-  await page.getByRole('button', { name: '저장' }).click();
+  await page.getByRole('button', { name: '작업 만들기' }).click();
 
   // 모달 닫힘
-  await expect(page.getByRole('dialog')).not.toBeVisible();
+  await expect(page.getByText('새로운 작업을 만듭니다')).not.toBeVisible();
 
   // 목록에 새 행 반영
-  await expect(page.getByRole('cell', { name: '기획 회의' })).toBeVisible();
-  await expect(page.getByRole('cell', { name: '김PM' })).toBeVisible();
+  await expect(page.getByText('기획 회의', { exact: true })).toBeVisible();
+  await expect(page.getByText('김PM', { exact: true })).toBeVisible();
   await expect(page.getByText('할 일')).toBeVisible();
   await expect(page.getByText('0%')).toBeVisible();
 
@@ -30,15 +30,15 @@ test('J2 — 최상위 작업 추가', async ({ page }) => {
 
 test('J17 — 목표 기한이 시작일보다 앞이면 저장 실패', async ({ page }) => {
   await page.goto('/');
-  await page.getByRole('button', { name: '+ 작업 추가' }).click();
+  await page.getByRole('button', { name: '작업 추가' }).click();
 
   await page.getByLabel('제목').fill('테스트 작업');
   await page.getByLabel('시작일').fill('2026-05-10');
   await page.getByLabel('목표 기한').fill('2026-05-05');
-  await page.getByRole('button', { name: '저장' }).click();
+  await page.getByRole('button', { name: '작업 만들기' }).click();
 
   // 모달 유지 (저장 안 됨)
-  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByText('새로운 작업을 만듭니다')).toBeVisible();
   await expect(
     page.getByText('목표 기한은 시작일 이후여야 합니다')
   ).toBeVisible();

--- a/e2e/task-create.spec.ts
+++ b/e2e/task-create.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTasks } from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await cleanupTasks(request);
+});
+
+test('J2 — 최상위 작업 추가', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: '+ 작업 추가' }).click();
+
+  await page.getByLabel('제목').fill('기획 회의');
+  await page.getByLabel('담당자').fill('김PM');
+  await page.getByLabel('시작일').fill('2026-05-01');
+  await page.getByLabel('목표 기한').fill('2026-05-03');
+  await page.getByRole('button', { name: '저장' }).click();
+
+  // 모달 닫힘
+  await expect(page.getByRole('dialog')).not.toBeVisible();
+
+  // 목록에 새 행 반영
+  await expect(page.getByRole('cell', { name: '기획 회의' })).toBeVisible();
+  await expect(page.getByRole('cell', { name: '김PM' })).toBeVisible();
+  await expect(page.getByText('할 일')).toBeVisible();
+  await expect(page.getByText('0%')).toBeVisible();
+
+  // 빈 상태 안내 사라짐
+  await expect(page.getByText('아직 작업이 없습니다')).not.toBeVisible();
+});
+
+test('J17 — 목표 기한이 시작일보다 앞이면 저장 실패', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: '+ 작업 추가' }).click();
+
+  await page.getByLabel('제목').fill('테스트 작업');
+  await page.getByLabel('시작일').fill('2026-05-10');
+  await page.getByLabel('목표 기한').fill('2026-05-05');
+  await page.getByRole('button', { name: '저장' }).click();
+
+  // 모달 유지 (저장 안 됨)
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(
+    page.getByText('목표 기한은 시작일 이후여야 합니다')
+  ).toBeVisible();
+});

--- a/e2e/task-delete.spec.ts
+++ b/e2e/task-delete.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTasks } from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await cleanupTasks(request);
+
+  // 부모 task 생성
+  const parentRes = await request.post('/api/tasks', {
+    data: { title: '기획 회의' },
+  });
+  const parent = await parentRes.json();
+
+  // 자식 task 생성
+  await request.post('/api/tasks', {
+    data: { title: '아젠다 초안 작성', parentId: parent.id },
+  });
+});
+
+test('J8 — 하위를 가진 작업 삭제', async ({ page }) => {
+  await page.goto('/');
+
+  // ⋯ 메뉴 → 삭제 (aria-label="메뉴" 기준)
+  const parentRow = page.getByRole('row', { name: /기획 회의/ });
+  await parentRow.getByRole('button', { name: '메뉴' }).click();
+  await page.getByRole('menuitem', { name: '삭제' }).click();
+
+  // 확인 다이얼로그 문구 검증
+  await expect(page.getByRole('alertdialog')).toBeVisible();
+  await expect(
+    page.getByText('이 작업과 하위 작업 1개가 모두 삭제됩니다. 계속할까요?')
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: '확인' }).click();
+
+  // 두 행 모두 사라짐
+  await expect(page.getByRole('cell', { name: '기획 회의' })).not.toBeVisible();
+  await expect(page.getByRole('cell', { name: '아젠다 초안 작성' })).not.toBeVisible();
+
+  // 새로고침 후에도 복구 안 됨
+  await page.reload();
+  await expect(page.getByRole('cell', { name: '기획 회의' })).not.toBeVisible();
+});

--- a/e2e/task-delete.spec.ts
+++ b/e2e/task-delete.spec.ts
@@ -19,24 +19,21 @@ test.beforeEach(async ({ request }) => {
 test('J8 — 하위를 가진 작업 삭제', async ({ page }) => {
   await page.goto('/');
 
-  // ⋯ 메뉴 → 삭제 (aria-label="메뉴" 기준)
-  const parentRow = page.getByRole('row', { name: /기획 회의/ });
-  await parentRow.getByRole('button', { name: '메뉴' }).click();
-  await page.getByRole('menuitem', { name: '삭제' }).click();
+  // 첫 번째 ⋯ 메뉴 클릭 (부모 작업 "기획 회의" 행)
+  await page.getByRole('button', { name: '메뉴' }).first().click();
+  await page.getByRole('button', { name: '삭제' }).click();
 
   // 확인 다이얼로그 문구 검증
-  await expect(page.getByRole('alertdialog')).toBeVisible();
-  await expect(
-    page.getByText('이 작업과 하위 작업 1개가 모두 삭제됩니다. 계속할까요?')
-  ).toBeVisible();
+  await expect(page.getByText('작업을 삭제할까요?')).toBeVisible();
+  await expect(page.getByText('하위 작업 1개')).toBeVisible();
 
-  await page.getByRole('button', { name: '확인' }).click();
+  await page.getByRole('button', { name: '삭제' }).click();
 
   // 두 행 모두 사라짐
-  await expect(page.getByRole('cell', { name: '기획 회의' })).not.toBeVisible();
-  await expect(page.getByRole('cell', { name: '아젠다 초안 작성' })).not.toBeVisible();
+  await expect(page.getByText('기획 회의', { exact: true })).not.toBeVisible();
+  await expect(page.getByText('아젠다 초안 작성', { exact: true })).not.toBeVisible();
 
   // 새로고침 후에도 복구 안 됨
   await page.reload();
-  await expect(page.getByRole('cell', { name: '기획 회의' })).not.toBeVisible();
+  await expect(page.getByText('기획 회의', { exact: true })).not.toBeVisible();
 });

--- a/e2e/task-list.spec.ts
+++ b/e2e/task-list.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTasks } from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await cleanupTasks(request);
+});
+
+test('J1 — 빈 상태 화면', async ({ page }) => {
+  await page.goto('/');
+  await expect(
+    page.getByText('아직 작업이 없습니다. 첫 작업을 추가해 시작하세요')
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: '+ 작업 추가' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'CSV 내보내기' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'CSV 불러오기' })).toBeVisible();
+});

--- a/e2e/task-list.spec.ts
+++ b/e2e/task-list.spec.ts
@@ -7,10 +7,8 @@ test.beforeEach(async ({ request }) => {
 
 test('J1 — 빈 상태 화면', async ({ page }) => {
   await page.goto('/');
-  await expect(
-    page.getByText('아직 작업이 없습니다. 첫 작업을 추가해 시작하세요')
-  ).toBeVisible();
-  await expect(page.getByRole('button', { name: '+ 작업 추가' })).toBeVisible();
+  await expect(page.getByText('아직 작업이 없습니다')).toBeVisible();
+  await expect(page.getByRole('button', { name: '작업 추가' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'CSV 내보내기' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'CSV 불러오기' })).toBeVisible();
 });

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,0 +1,11 @@
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+
+const globalForDb = globalThis as unknown as { sql: postgres.Sql };
+
+// dev 환경 핫 리로드 시 커넥션 누수 방지
+const sql = globalForDb.sql ?? postgres(process.env.DATABASE_URL!);
+if (process.env.NODE_ENV !== 'production') globalForDb.sql = sql;
+
+export const db = drizzle(sql, { schema });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,0 +1,23 @@
+import { pgTable, uuid, text, integer, date, timestamp, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    parentId: uuid('parent_id').references((): any => tasks.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    description: text('description'),
+    assignee: text('assignee'),
+    status: text('status').notNull().default('todo'),
+    progress: integer('progress').notNull().default(0),
+    startDate: date('start_date'),
+    dueDate: date('due_date'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    statusCheck: check('tasks_status_check', sql`${t.status} in ('todo','doing','done')`),
+    progressCheck: check('tasks_progress_check', sql`${t.progress} between 0 and 100`),
+  })
+);

--- a/lib/utils/tree.ts
+++ b/lib/utils/tree.ts
@@ -1,0 +1,27 @@
+import type { Task, TaskNode } from '@/types/task';
+
+export function buildTree(tasks: Task[]): TaskNode[] {
+  const map = new Map<string, TaskNode>();
+  for (const t of tasks) map.set(t.id, { ...t, children: [] });
+
+  const roots: TaskNode[] = [];
+  for (const node of map.values()) {
+    if (node.parentId && map.has(node.parentId)) {
+      map.get(node.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}
+
+export function flattenTree(nodes: TaskNode[], collapsedIds: Set<string>): TaskNode[] {
+  const result: TaskNode[] = [];
+  for (const node of nodes) {
+    result.push(node);
+    if (!collapsedIds.has(node.id)) {
+      result.push(...flattenTree(node.children, collapsedIds));
+    }
+  }
+  return result;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6",
         "@testing-library/react": "^16",
         "@types/node": "^20",
@@ -1824,6 +1825,22 @@
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.10.0.tgz",
       "integrity": "sha512-OmEHkDj3BRkHYLxHwNFYJkcwF84c7PuHsWHmmmNLJnmk8z0RVlDQei4GxWjfW1bnvCihCwakJ8Xq6GDRlmcDiQ==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -4763,6 +4780,52 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -6668,22 +6731,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,28 +9,30 @@
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
-    "next": "^14.2.29",
-    "react": "^18",
-    "react-dom": "^18",
     "@chakra-ui/react": "^3",
     "@emotion/react": "^11",
+    "@supabase/supabase-js": "^2",
     "drizzle-orm": "^0.44.2",
+    "next": "^14.2.29",
     "postgres": "^3",
-    "@supabase/supabase-js": "^2"
+    "react": "^18",
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/react": "^16",
+    "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@types/node": "^20",
-    "drizzle-kit": "^0.31.1",
-    "vitest": "^3",
     "@vitejs/plugin-react": "^4",
+    "drizzle-kit": "^0.31.1",
     "jsdom": "^26",
-    "@testing-library/react": "^16",
-    "@testing-library/jest-dom": "^6"
+    "typescript": "^5",
+    "vitest": "^3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+  },
+});

--- a/types/task.ts
+++ b/types/task.ts
@@ -1,0 +1,19 @@
+export type TaskStatus = 'todo' | 'doing' | 'done';
+
+export interface Task {
+  id: string;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  assignee: string | null;
+  status: TaskStatus;
+  progress: number;
+  startDate: string | null;
+  dueDate: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskNode extends Task {
+  children: TaskNode[];
+}


### PR DESCRIPTION
## 관련 이슈
Closes #3

## 요약

이슈 #3 "Task 생성 / 목록 표시 / 삭제" 구현 (TDD 4단계 완료)

- **[3-1] Red** — Playwright E2E 테스트 파일 작성 (J1·J2·J8·J17), 실패 확인
- **[3-2] Green** — API Routes + UI 컴포넌트 구현
- **[3-3] Green 확인** — E2E 테스트 4개 전부 통과
- **[3-4] Refactor** — 빌드 검증 완료, 최종 커밋

## 변경 파일

### Backend
- `app/api/tasks/route.ts` — GET(목록 조회), POST(생성)
- `app/api/tasks/[id]/route.ts` — DELETE(삭제, cascade는 DB FK 처리)
- `lib/db/index.ts` — Drizzle postgres-js 클라이언트
- `lib/utils/tree.ts` — buildTree / flattenTree 유틸리티

### Frontend
- `app/page.tsx` — 메인 페이지 (툴바 + TaskList)
- `components/task-list.tsx` — 목록 + 빈 상태 안내 (J1)
- `components/task-row.tsx` — 작업 행 + ⋯ 메뉴(삭제)
- `components/task-create-modal.tsx` — 생성 모달, J17 날짜 유효성 포함
- `components/task-delete-dialog.tsx` — 삭제 확인 다이얼로그 (하위 N개 문구)

### 테스트
- `e2e/task-list.spec.ts` — J1
- `e2e/task-create.spec.ts` — J2, J17
- `e2e/task-delete.spec.ts` — J8
- `e2e/helpers.ts` — cleanupTasks (테스트 격리용)
- `playwright.config.ts` — workers: 1 (공유 DB 환경 순차 실행)

## 테스트 계획

```
[ ] npm run build — 빌드 오류 없음 ✅
[ ] npm run test:e2e — J1·J2·J8·J17 전부 통과 ✅
[ ] 브라우저 수동 확인 — http://localhost:3000
    [ ] J1: 빈 상태 화면 표시
    [ ] J2: + 작업 추가 → 모달 → 저장 → 목록 반영
    [ ] J8: ⋯ → 삭제 → 다이얼로그(하위 N개) → 확인 → cascade 삭제
    [ ] J17: 목표 기한 < 시작일 → 오류 메시지
```

## 범위 밖 (다음 이슈)
- 계층 들여쓰기 · 접기/펼치기 → 이슈 #4
- 인라인 상태 순환 · 수정 모달 · 진행률 자동 완료 → 이슈 #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)