### PR TITLE
feat: #5 진행률·상태·담당자·시작일·목표기한 편집 TDD

### DIFF
--- a/components/task-edit-modal.tsx
+++ b/components/task-edit-modal.tsx
@@ -42,6 +42,7 @@ export function TaskEditModal({ task, allTasks, open, onClose, onSaved }: Props)
   const [startDate, setStartDate] = useState(task.startDate ?? '')
   const [dueDate, setDueDate] = useState(task.dueDate ?? '')
   const [titleError, setTitleError] = useState(false)
+  const [dateError, setDateError] = useState(false)
   const [saving, setSaving] = useState(false)
   const [delivs, setDelivs] = useState<Deliverable[]>(task.deliverables ?? [])
   const parentTask = task.parentId ? allTasks.find(t => t.id === task.parentId) : null
@@ -80,6 +81,7 @@ export function TaskEditModal({ task, allTasks, open, onClose, onSaved }: Props)
 
   const handleSave = async () => {
     if (!title.trim()) { setTitleError(true); return }
+    if (startDate && dueDate && dueDate < startDate) { setDateError(true); return }
     setSaving(true)
     await fetch(`/api/tasks/${task.id}`, {
       method: 'PATCH',
@@ -130,6 +132,7 @@ export function TaskEditModal({ task, allTasks, open, onClose, onSaved }: Props)
             <div>
               <FieldLabel label="제목" en="Title" />
               <input
+                aria-label="제목"
                 style={{ ...inputStyle, borderColor: titleError ? '#DC2626' : '#E2E8F0' }}
                 value={title}
                 onChange={e => { setTitle(e.target.value); setTitleError(false) }}
@@ -207,11 +210,16 @@ export function TaskEditModal({ task, allTasks, open, onClose, onSaved }: Props)
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
               <div>
                 <FieldLabel label="시작일" en="Start" />
-                <input type="date" style={inputStyle} value={startDate} onChange={e => setStartDate(e.target.value)} />
+                <input aria-label="시작일" type="date" style={inputStyle} value={startDate} onChange={e => { setStartDate(e.target.value); setDateError(false) }} />
               </div>
               <div>
                 <FieldLabel label="목표 기한" en="Due" />
-                <input type="date" style={inputStyle} value={dueDate} onChange={e => setDueDate(e.target.value)} />
+                <input aria-label="목표 기한" type="date" style={inputStyle} value={dueDate} onChange={e => { setDueDate(e.target.value); setDateError(false) }} />
+                {dateError && (
+                  <div style={{ fontSize: '11px', color: '#DC2626', marginTop: '4px' }}>
+                    ⚠ 목표 기한은 시작일 이후여야 합니다
+                  </div>
+                )}
               </div>
             </div>
 

--- a/e2e/task-edit.spec.ts
+++ b/e2e/task-edit.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTasks } from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await cleanupTasks(request);
+});
+
+test('J5 — 진행률 100% → 상태 자동 "완료"', async ({ page, request }) => {
+  await request.post('/api/tasks', { data: { title: '아젠다 초안 작성' } });
+  await page.goto('/');
+
+  await page.getByText('아젠다 초안 작성', { exact: true }).click();
+  await expect(page.getByText('작업 편집')).toBeVisible();
+
+  // React가 변경을 감지하도록 native setter + input 이벤트 방식 사용
+  const slider = page.locator('input[type="range"]');
+  await slider.evaluate((el: HTMLInputElement) => {
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    nativeSetter.call(el, '100');
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+
+  await page.getByRole('button', { name: '저장' }).click();
+  await expect(page.getByText('작업 편집')).not.toBeVisible();
+
+  // 목록에서 상태 배지 "완료" 확인
+  await expect(page.getByText('완료', { exact: true })).toBeVisible();
+});
+
+test('J6 — 상태 배지 인라인 순환 전환', async ({ page, request }) => {
+  await request.post('/api/tasks', { data: { title: '기획 회의' } });
+  await page.goto('/');
+
+  // 초기 상태 확인
+  await expect(page.getByText('할 일', { exact: true })).toBeVisible();
+
+  // 클릭 1: 할 일 → 진행 중
+  await page.getByText('할 일', { exact: true }).click();
+  await expect(page.getByText('진행 중', { exact: true })).toBeVisible();
+
+  // 클릭 2: 진행 중 → 완료
+  await page.getByText('진행 중', { exact: true }).click();
+  await expect(page.getByText('완료', { exact: true })).toBeVisible();
+
+  // 클릭 3: 완료 → 할 일
+  await page.getByText('완료', { exact: true }).click();
+  await expect(page.getByText('할 일', { exact: true })).toBeVisible();
+
+  // 새로고침 후에도 마지막 상태(할 일) 유지
+  await page.reload();
+  await expect(page.getByText('할 일', { exact: true })).toBeVisible();
+});
+
+test('J7 — 작업 제목 수정', async ({ page, request }) => {
+  await request.post('/api/tasks', { data: { title: '기획 회의' } });
+  await page.goto('/');
+
+  await page.getByText('기획 회의', { exact: true }).click();
+  await expect(page.getByText('작업 편집')).toBeVisible();
+
+  const titleInput = page.getByLabel('제목');
+  await titleInput.clear();
+  await titleInput.fill('킥오프 미팅');
+  await page.getByRole('button', { name: '저장' }).click();
+
+  await expect(page.getByText('킥오프 미팅', { exact: true })).toBeVisible();
+  await expect(page.getByText('기획 회의', { exact: true })).not.toBeVisible();
+});
+
+test('편집 모달 — 목표 기한이 시작일보다 앞이면 저장 실패', async ({ page, request }) => {
+  await request.post('/api/tasks', { data: { title: '테스트 작업' } });
+  await page.goto('/');
+
+  await page.getByText('테스트 작업', { exact: true }).click();
+  await expect(page.getByText('작업 편집')).toBeVisible();
+
+  await page.getByLabel('시작일').fill('2026-05-10');
+  await page.getByLabel('목표 기한').fill('2026-05-05');
+  await page.getByRole('button', { name: '저장' }).click();
+
+  // 모달 유지, 에러 메시지 표시
+  await expect(page.getByText('작업 편집')).toBeVisible();
+  await expect(page.getByText('목표 기한은 시작일 이후여야 합니다')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- `task-edit-modal.tsx` — 편집 모달에 날짜 역순 검증 추가 (목표 기한 < 시작일 시 저장 차단)
- `task-edit-modal.tsx` — `aria-label` 추가(제목·시작일·목표 기한) — E2E 접근성 개선
- `e2e/task-edit.spec.ts` 신규 — J5·J6·J7 + 날짜 역순 검증 4개 E2E 테스트

## 구현된 시나리오 (USER_JOURNEY.md)

| ID | 시나리오 | 결과 |
|---|---|---|
| J5 | 진행률 100% → 상태 자동 "완료" | ✅ PASS |
| J6 | 상태 배지 인라인 순환 전환 (할 일→진행 중→완료→할 일) | ✅ PASS |
| J7 | 작업 제목 수정 후 목록 즉시 반영 | ✅ PASS |
| — | 편집 모달 날짜 역순 입력 저장 차단 | ✅ PASS |

## Test plan

- [x] `npx playwright test e2e/task-edit.spec.ts` → 4 passed
- [x] `npx playwright test` (전체 회귀) → 10 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)