### PR TITLE
fix: supabase 로컬 포트 충돌 방지 (config.toml)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,7 +7,7 @@ project_id = "claude-vercel-wbs"
 [api]
 enabled = true
 # Port to use for the API URL.
-port = 54321
+port = 54330
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
@@ -26,9 +26,9 @@ enabled = false
 
 [db]
 # Port to use for the local database URL.
-port = 54322
+port = 54400
 # Port used by db diff command to initialize the shadow database.
-shadow_port = 54320
+shadow_port = 54401
 # Maximum amount of time to wait for health check when starting the local database.
 health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
@@ -88,7 +88,7 @@ enabled = true
 [studio]
 enabled = true
 # Port to use for Supabase Studio.
-port = 54323
+port = 54331
 # External URL of the API server that frontend connects to.
 api_url = "http://127.0.0.1"
 # OpenAI API Key to use for Supabase AI in the Supabase Studio.


### PR DESCRIPTION
## Summary

- `supabase/config.toml` 포트 번호 조정 (54321→54330, 54322→54400 등) — 로컬 환경 포트 충돌 방지

> PR #24에서 이슈 #6 CSV 기능은 완료됐으나, 이 설정 파일 변경만 누락되어 별도 반영합니다.

## Test plan

- [x] 기존 E2E 18건 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)